### PR TITLE
Add support for windowName (equals or contains) configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/*
 package-lock.json
 slobs-stream-switcher-*
 *.zip
+config.json

--- a/config.json.dist
+++ b/config.json.dist
@@ -4,6 +4,12 @@
 	"scenes": [
 		{
 			"windowClassName": "Code.exe",
+			"windowName": { "name": "ide - project1", "contains": true },
+			"targetScene": "CodeScene"
+		},
+		{
+			"windowClassName": "Code.exe",
+			"windowName": { "name": "ide - project2", "contains": true },
 			"targetScene": "CodeScene"
 		},
 		{

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "author": "stuyk",
     "license": "ISC",
     "dependencies": {
-        "active-windows": "^0.1.12",
+        "active-windows": "^0.1.14",
         "chalk": "^4.1.0",
         "sockjs-client": "^1.4.0"
     },


### PR DESCRIPTION
This will allow for providing the window name as part of the comparator for selecting the scene. This is useful in cases where you're running multiple of the same window with different names (e.g. coding project ide's).

Also ignore config.json and added config.json.dist to the tracking as the example config json file.